### PR TITLE
Fix dynamic state type handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.7.5-dev
+
+- Fix dynamic state type handling
+- Automatically repair incorrect ioBroker state types
+- Improved compatibility with js-controller 7
+- Better handling of string based Solarman values

--- a/README.md
+++ b/README.md
@@ -59,12 +59,26 @@ In version 0.7.1, only minor adjustments were made to the instance view.
 Potentially sensitive data such as “activeToken” should be encrypted, but
 this does not work reliably. Therefore, this was rolled back in version 0.7.3.
 
+## Compatibility
+
+- Tested with Node.js 22
+- Tested with js-controller 7
+- Incorrectly typed existing ioBroker states are repaired automatically during the next adapter run
+- Manual deletion of existing objects is not required
+
 ## Changelog
 
 <!--
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+
+### 0.7.5-dev
+
+- Fix dynamic state type handling
+- Automatically repair incorrect ioBroker state types
+- Improved compatibility with js-controller 7
+- Better handling of string based Solarman values
 
 ### 0.7.4 (2026-05-29)
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,21 @@
 {
   "common": {
     "name": "solarmanpv",
-    "version": "0.7.4",
+    "version": "0.7.5-dev",
     "news": {
+      "0.7.5-dev": {
+        "en": "Fix dynamic state type handling\nAutomatically repair incorrect ioBroker state types\nImproved compatibility with js-controller 7\nBetter handling of string based Solarman values",
+        "de": "Dynamische State-Typ-Behandlung korrigiert\nFalsch typisierte ioBroker-States werden automatisch repariert\nVerbesserte Kompatibilität mit js-controller 7\nBessere Behandlung stringbasierter Solarman-Werte",
+        "ru": "Исправлена динамическая обработка типов состояний\nАвтоматическое исправление неверных типов состояний ioBroker\nУлучшена совместимость с js-controller 7\nУлучшена обработка строковых значений Solarman",
+        "pt": "Corrigido o tratamento dinâmico de tipos de estados\nCorreção automática de tipos de estados ioBroker incorretos\nCompatibilidade melhorada com js-controller 7\nMelhor tratamento de valores Solarman baseados em texto",
+        "nl": "Dynamische state-typeafhandeling opgelost\nOnjuiste ioBroker-state-types worden automatisch hersteld\nVerbeterde compatibiliteit met js-controller 7\nBetere verwerking van tekstwaarden van Solarman",
+        "fr": "Correction de la gestion dynamique des types d'etats\nCorrection automatique des types d'etats ioBroker incorrects\nCompatibilite amelioree avec js-controller 7\nMeilleure gestion des valeurs Solarman sous forme de texte",
+        "it": "Corretta la gestione dinamica dei tipi di stato\nRiparazione automatica dei tipi di stato ioBroker errati\nCompatibilita migliorata con js-controller 7\nMigliore gestione dei valori Solarman testuali",
+        "es": "Corregido el manejo dinamico de tipos de estado\nReparacion automatica de tipos de estado ioBroker incorrectos\nCompatibilidad mejorada con js-controller 7\nMejor manejo de valores Solarman basados en texto",
+        "pl": "Naprawiono dynamiczna obsluge typow stanow\nAutomatyczna naprawa nieprawidlowych typow stanow ioBroker\nLepsza zgodnosc z js-controller 7\nLepsza obsluga tekstowych wartosci Solarman",
+        "uk": "Виправлено динамічну обробку типів станів\nАвтоматичне виправлення неправильних типів станів ioBroker\nПокращена сумісність з js-controller 7\nКраща обробка текстових значень Solarman",
+        "zh-cn": "修复动态状态类型处理\n自动修复错误的 ioBroker 状态类型\n改进与 js-controller 7 的兼容性\n更好地处理基于字符串的 Solarman 值"
+      },
       "0.7.4": {
         "en": "Bump axios from 1.13.6 to 1.16.1\nRemoved the unused 'paket' module\nNodeJS >= 22.x is required",
         "de": "Bump axios von 1.13.6 bis 1.16.1\nEntfernen des ungenutzten Moduls 'Paket'\nNodeJS >= 22.x erforderlich",

--- a/lib/stateType.js
+++ b/lib/stateType.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const NUMERIC_VALUE_PATTERN = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i;
+
+/**
+ * @param value value to check
+ * @returns true if the value can be stored as an ioBroker number state
+ */
+function isNumericStateValue(value) {
+	if (typeof value === 'number') {
+		return Number.isFinite(value);
+	}
+	if (typeof value !== 'string') {
+		return false;
+	}
+
+	const trimmedValue = value.trim();
+	return trimmedValue !== '' && NUMERIC_VALUE_PATTERN.test(trimmedValue) && Number.isFinite(Number(trimmedValue));
+}
+
+/**
+ * @param value raw Solarman value
+ * @returns value normalized for the ioBroker state type
+ */
+function normalizeStateValue(value) {
+	if (value === null || value === undefined) {
+		return '';
+	}
+	if (typeof value === 'string') {
+		if (value.trim() === '') {
+			return '';
+		}
+		return isNumericStateValue(value) ? Number(value.trim()) : value;
+	}
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? value : String(value);
+	}
+
+	return String(value);
+}
+
+/**
+ * @param value normalized value
+ * @returns ioBroker common.type for the value
+ */
+function getStateType(value) {
+	return typeof value === 'number' ? 'number' : 'string';
+}
+
+module.exports = {
+	getStateType,
+	isNumericStateValue,
+	normalizeStateValue,
+};

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@
 const utils = require('@iobroker/adapter-core');
 const crypto5 = require('node:crypto');
 const api = require('./lib/solarmanpvApiClient.js');
+const { getStateType, normalizeStateValue } = require('./lib/stateType.js');
 
 class Solarmanpv extends utils.Adapter {
 	/**
@@ -137,7 +138,6 @@ class Solarmanpv extends utils.Adapter {
 			sensorName = `${device}.${description}`;
 		}
 		const dp_Device = String(`${dp_Folder}.${name}`);
-		//this.log.debug(`[persistData] Station "${station}" Device "${device}" Name "${name}" Sensor "${description}" with value: "${value}" and unit "${unit}" as role "${role}`);
 		this.log.silly(`[persistData] Sensorname "${sensorName}"`);
 		//
 		await this.setObjectNotExists(dp_Folder, {
@@ -162,8 +162,8 @@ class Solarmanpv extends utils.Adapter {
 			native: {},
 		});
 		//
-		const stateValue = nullable ? 0 : normalizeValue(value);
-		const stateType = isNumber(stateValue) ? 'number' : 'string';
+		const stateValue = nullable ? 0 : normalizeStateValue(value);
+		const stateType = getStateType(stateValue);
 		/** @satisfies {ioBroker.StateCommon} */
 		const stateCommon = {
 			name: name,
@@ -179,11 +179,13 @@ class Solarmanpv extends utils.Adapter {
 			common: stateCommon,
 			native: {},
 		});
+		// setObjectNotExistsAsync does not update existing objects. Therefore getObjectAsync is
+		// required to detect states that were created with an outdated or wrong common.type.
 		const stateObject = await this.getObjectAsync(dp_Device);
 		if (stateObject?.common?.type !== stateType) {
-			this.log.debug(
-				`[persistData] Correcting type of "${dp_Device}" from "${stateObject?.common?.type}" to "${stateType}"`,
-			);
+			// ioBroker validates the state value against common.type. Repair the object first
+			// so string based Solarman values such as "--" or "N/A" are not written to number states.
+			this.log.debug(`Correcting state type:\n${dp_Device}\n${stateObject?.common?.type} -> ${stateType}`);
 			await this.extendObjectAsync(dp_Device, {
 				type: 'state',
 				common: stateCommon,
@@ -193,30 +195,9 @@ class Solarmanpv extends utils.Adapter {
 		if (nullable) {
 			await this.setState(dp_Device, { val: 0, ack: true, q: 0x42 }); // Nullable values while device is not present
 		} else {
+			// setState must run after the optional extendObjectAsync call. Otherwise js-controller
+			// may reject the value because it still sees the previous common.type.
 			await this.setState(dp_Device, { val: stateValue, ack: true, q: 0x00 });
-		}
-		//
-		function isNumber(n) {
-			if (typeof n === 'number') {
-				return Number.isFinite(n);
-			}
-			if (typeof n !== 'string') {
-				return false;
-			}
-			const trimmedValue = n.trim();
-			return (
-				/^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i.test(trimmedValue) && Number.isFinite(Number(trimmedValue))
-			);
-		}
-
-		function normalizeValue(n) {
-			if (n === null || n === undefined) {
-				return '';
-			}
-			if (typeof n === 'string' && n.trim() === '') {
-				return '';
-			}
-			return isNumber(n) ? Number(n) : n;
 		}
 	}
 

--- a/main.js
+++ b/main.js
@@ -162,48 +162,61 @@ class Solarmanpv extends utils.Adapter {
 			native: {},
 		});
 		//
-		// Type recognition <number>
-		if (isNumber(value)) {
-			value = parseFloat(value);
-			//
-			await this.setObjectNotExistsAsync(dp_Device, {
+		const stateValue = nullable ? 0 : normalizeValue(value);
+		const stateType = isNumber(stateValue) ? 'number' : 'string';
+		/** @satisfies {ioBroker.StateCommon} */
+		const stateCommon = {
+			name: name,
+			type: stateType,
+			role: role,
+			unit: unit,
+			read: true,
+			write: true,
+		};
+		//
+		await this.setObjectNotExistsAsync(dp_Device, {
+			type: 'state',
+			common: stateCommon,
+			native: {},
+		});
+		const stateObject = await this.getObjectAsync(dp_Device);
+		if (stateObject?.common?.type !== stateType) {
+			this.log.debug(
+				`[persistData] Correcting type of "${dp_Device}" from "${stateObject?.common?.type}" to "${stateType}"`,
+			);
+			await this.extendObjectAsync(dp_Device, {
 				type: 'state',
-				common: {
-					name: name,
-					type: 'number',
-					role: role,
-					unit: unit,
-					read: true,
-					write: true,
-				},
-				native: {},
+				common: stateCommon,
 			});
-			//this.log.debug(`[persistData] Device "${dp_Device}"  Key "${key}" with value: "${value}" and unit "${unit}" with role "${role}" as type "number"`);
-		} else {
-			// or <string>
-			await this.setObjectNotExistsAsync(dp_Device, {
-				type: 'state',
-				common: {
-					name: name,
-					type: 'string',
-					role: role,
-					unit: unit,
-					read: true,
-					write: true,
-				},
-				native: {},
-			});
-			//this.log.debug(`[persistData] Device "${dp_Device}"  Key "${key}" with value: "${value}" and unit "${unit}" with role "${role}" as type "string"`);
 		}
 		// Differentiated writing of data
 		if (nullable) {
 			await this.setState(dp_Device, { val: 0, ack: true, q: 0x42 }); // Nullable values while device is not present
 		} else {
-			await this.setState(dp_Device, { val: value, ack: true, q: 0x00 });
+			await this.setState(dp_Device, { val: stateValue, ack: true, q: 0x00 });
 		}
 		//
 		function isNumber(n) {
-			return !isNaN(parseFloat(n)) && !isNaN(n - 0);
+			if (typeof n === 'number') {
+				return Number.isFinite(n);
+			}
+			if (typeof n !== 'string') {
+				return false;
+			}
+			const trimmedValue = n.trim();
+			return (
+				/^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i.test(trimmedValue) && Number.isFinite(Number(trimmedValue))
+			);
+		}
+
+		function normalizeValue(n) {
+			if (n === null || n === undefined) {
+				return '';
+			}
+			if (typeof n === 'string' && n.trim() === '') {
+				return '';
+			}
+			return isNumber(n) ? Number(n) : n;
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "iobroker.solarmanpv",
-	"version": "0.7.4",
+	"version": "0.7.5-dev",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "iobroker.solarmanpv",
-			"version": "0.7.4",
+			"version": "0.7.5-dev",
 			"license": "MIT",
 			"dependencies": {
 				"@iobroker/adapter-core": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "iobroker.solarmanpv",
-	"version": "0.7.4",
+	"version": "0.7.5-dev",
 	"description": "Reading data from balcony power plant",
 	"author": {
 		"name": "raschy",

--- a/stateType.test.js
+++ b/stateType.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const { getStateType, normalizeStateValue } = require('./lib/stateType.js');
+
+describe('state type handling', () => {
+	const stringCases = [
+		[null, ''],
+		[undefined, ''],
+		['', ''],
+		[' ', ''],
+		['--', '--'],
+		['N/A', 'N/A'],
+		['none', 'none'],
+		['null', 'null'],
+		[Infinity, 'Infinity'],
+		[NaN, 'NaN'],
+		['0x10', '0x10'],
+		[true, 'true'],
+		[false, 'false'],
+	];
+
+	for (const [input, expected] of stringCases) {
+		it(`normalizes ${String(input)} as string`, () => {
+			const value = normalizeStateValue(input);
+			value.should.equal(expected);
+			getStateType(value).should.equal('string');
+		});
+	}
+
+	const numberCases = [
+		['0', 0],
+		['42', 42],
+		[' 42 ', 42],
+		['-13.5', -13.5],
+		['.5', 0.5],
+		['1e3', 1000],
+		[23, 23],
+	];
+
+	for (const [input, expected] of numberCases) {
+		it(`normalizes ${String(input)} as number`, () => {
+			const value = normalizeStateValue(input);
+			value.should.equal(expected);
+			getStateType(value).should.equal('number');
+		});
+	}
+});


### PR DESCRIPTION
## Summary
- fix dynamic state type handling in `persistData()`
- automatically repair existing ioBroker state objects with an incorrect `common.type`
- normalize string based Solarman values so placeholders and text are written to string states
- document js-controller 7 compatibility and add regression tests for edge cases

## Details
`setObjectNotExistsAsync()` does not update already existing objects. The adapter now reads the object with `getObjectAsync()`, compares the existing `common.type` with the type derived from the normalized value, and repairs mismatches with `extendObjectAsync()` before calling `setState()`.

This keeps existing datapoint names and object paths unchanged and avoids writing values such as `--`, `N/A`, `none`, booleans, `NaN`, `Infinity`, or hex-like strings into number states.

## Tests
- `npm test`
- `npm run check`
- `npm run lint`
- `npx eslint -c eslint.config.mjs main.js`